### PR TITLE
fix: make ID blank when the resource isn't found

### DIFF
--- a/dmsnitch/resource_snitch.go
+++ b/dmsnitch/resource_snitch.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"io/ioutil"
 	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 type Snitch struct {
@@ -139,6 +140,10 @@ func resourceSnitchRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*DMSnitchClient)
 	resp, _ := client.Get(fmt.Sprintf("snitches/%s", d.Id()))
 
+	if resp.StatusCode == 404 {
+		d.SetId("")
+		return nil
+	}
 	if resp.StatusCode == 200 {
 		var snitch Snitch
 


### PR DESCRIPTION
https://www.terraform.io/docs/plugins/provider.html#read

> If the resource is no longer present, calling SetId with an empty string will signal its removal.

## Problem to solve

When a snitch created by this provider is removed manually,
it is failed to read (terraform plan, apply etc) because the resource isn't found.

```
Error: API Error: 404 https://api.deadmanssnitch.com/v1/snitches/*** The requested resource was not found.
```

## How to solve

By calling SetId with an empty string, Terraform treats the resource as removed, and read is succeeded.