### PR TITLE
Add alert_email

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ resource "dmsnitch_snitch" "mysnitch" {
   interval = "daily"
   type = "basic"
   tags = ["one", "two"]
+  alert_email = ["alice@example.com", "bob@example.com"]
 }
 ```
 
@@ -89,13 +90,14 @@ You can also import existing snitches using their token found in the snitch's pa
 
 ### Fields
 
-| Field      | Required                                                       | Values                                                           | Defaults               |
-| ---------- | -------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------- |
-| `name`     | yes                                                            |
-| `notes`    | no                                                             |                                                                  | `Managed by Terraform` |
-| `interval` | yes                                                            | `15_minute`, `30_minute`, `hourly`, `daily`, `weekly`, `monthly` | `daily`                |
-| `type`     | yes; `smart` is only valid for `weekly` or `monthly` intervals | `basic`, `smart`                                                 | `basic`                |
-| `tags`     | no                                                             | an array of values                                               |
+| Field         | Required                                                       | Values                                                           | Defaults               |
+| ------------- | -------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------- |
+| `name`        | yes                                                            |                                                                  |                        |
+| `notes`       | no                                                             |                                                                  | `Managed by Terraform` |
+| `interval`    | yes                                                            | `15_minute`, `30_minute`, `hourly`, `daily`, `weekly`, `monthly` | `daily`                |
+| `type`        | yes; `smart` is only valid for `weekly` or `monthly` intervals | `basic`, `smart`                                                 | `basic`                |
+| `tags`        | no                                                             | an array of values                                               |                        |
+| `alert_email` | no                                                             | an array of email addresses                                      |                        |
 
 ### Attributes
 


### PR DESCRIPTION
I, too, need `alert_email`, so this is just my version of #9. Thanks to @richarddouglasfrye for starting the process some 18 months ago.

Closes #8.

N.B. [Upstream](https://deadmanssnitch.com/docs/api/v1#creating-a-snitch) says:
> Value can be either an array of email addresses or a comma separated list of addresses. Use either null or [] to disable the override.

This change set **does not** support a comma-separated list of addresses.